### PR TITLE
Improve write loop

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -3,7 +3,6 @@
 #include <fcntl.h>
 #include <sys/socket.h>
 #include <netdb.h>
-#include <poll.h>
 
 #include "brubeck.h"
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <poll.h>
 
 #include "brubeck.h"
 


### PR DESCRIPTION
**The Theory:**

Brubeck tries to write to Carbon-relay. TCP window overwhelming and backpressure kick in, causing the relay's receive buffers to fill up. This results in the write(2) call returning 0. 

When write(2) returns 0, brubeck: a) sets ENOSPC (why?), b) returns early, and c) shitcans the entire buffer. This results in writes in the latter half of the buffer not making it.

Since the buffer is ordered (well, as ordered as https://github.com/concurrencykit/ck/blob/master/include/ck_ht.h, which is "kinda"), stats at the "bottom" of the buffer don't make it to the relays, causing partial statistic data loss.

**The Fix:**

Assuming that theory holds, this PR makes these changes:
- Waits for socket writability before each write(2) call.
- Since "writability" implies "doesn't block" not "data will make it" (i.e. writes can still return 0), retries and re-waits whenever we get a 0. Utterly superstitiously, I think a busy loop here might keep slinging data across the wire and really bum out the relay, but that's informed by an utterly sophomoric understanding of TCP, so take it with a grain.
- Adds better logging when writes fail so we can correlate that with other events in the system.