### PR TITLE
Fix Jammy build: migrate statsd-secure HMAC_CTX to OpenSSL 3 opaque API

### DIFF
--- a/src/samplers/statsd-secure.c
+++ b/src/samplers/statsd-secure.c
@@ -3,6 +3,25 @@
 #include <openssl/hmac.h>
 #include "brubeck.h"
 
+/* OpenSSL < 1.1.0 (bionic bakes pin libssl1.0-dev) has no heap HMAC_CTX API */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+static HMAC_CTX *HMAC_CTX_new(void)
+{
+	HMAC_CTX *ctx = malloc(sizeof(*ctx));
+	if (ctx)
+		HMAC_CTX_init(ctx);
+	return ctx;
+}
+
+static void HMAC_CTX_free(HMAC_CTX *ctx)
+{
+	if (ctx) {
+		HMAC_CTX_cleanup(ctx);
+		free(ctx);
+	}
+}
+#endif
+
 #define SHA_SIZE 32
 #define SHA_FUNCTION EVP_sha256
 

--- a/src/samplers/statsd-secure.c
+++ b/src/samplers/statsd-secure.c
@@ -98,7 +98,7 @@ static void *statsd_secure__thread(void *_in)
 
 	char buffer[MAX_PACKET_SIZE];
 
-	HMAC_CTX ctx;
+	HMAC_CTX *ctx;
 	unsigned char hmac_buffer[SHA_SIZE];
 	unsigned int hmac_len;
 
@@ -108,8 +108,8 @@ static void *statsd_secure__thread(void *_in)
 
 	log_splunk("sampler=statsd-secure event=worker_online");
 
-	HMAC_CTX_init(&ctx);
-	HMAC_Init_ex(&ctx, statsd->hmac_key, strlen(statsd->hmac_key), SHA_FUNCTION(), NULL);
+	ctx = HMAC_CTX_new();
+	HMAC_Init_ex(ctx, statsd->hmac_key, strlen(statsd->hmac_key), SHA_FUNCTION(), NULL);
 
 	for (;;) {
 		int res = recvfrom(statsd->sampler.in_sock, buffer,
@@ -133,9 +133,9 @@ static void *statsd_secure__thread(void *_in)
 			continue;
 		}
 
-		HMAC_Init_ex(&ctx, NULL, 0, NULL, NULL);
-		HMAC_Update(&ctx, (unsigned char *)buffer + SHA_SIZE, res - SHA_SIZE);
-		HMAC_Final(&ctx, hmac_buffer, &hmac_len);
+		HMAC_Init_ex(ctx, NULL, 0, NULL, NULL);
+		HMAC_Update(ctx, (unsigned char *)buffer + SHA_SIZE, res - SHA_SIZE);
+		HMAC_Final(ctx, hmac_buffer, &hmac_len);
 
 		if (memcmpct(buffer, hmac_buffer, SHA_SIZE) != 0) {
 			log_splunk("sampler=statsd-secure event=fail_auth hmac=%s", hmactos(buffer));
@@ -149,7 +149,7 @@ static void *statsd_secure__thread(void *_in)
 		brubeck_statsd_packet_parse(server, buffer + MIN_PACKET_SIZE, buffer + res);
 	}
 
-	HMAC_CTX_cleanup(&ctx);
+	HMAC_CTX_free(ctx);
 	return NULL;
 }
 


### PR DESCRIPTION
## Summary
- statsd-secure.c fails to compile on Jammy (OpenSSL 3): HMAC_CTX became an opaque type in OpenSSL 1.1+, so the stack-allocated `HMAC_CTX ctx;` and legacy `HMAC_CTX_init`/`HMAC_CTX_cleanup` calls no longer work.
- Switches to the modern heap-allocated API: `HMAC_CTX_new()` / `HMAC_CTX_free()`.
- Adds a version-guarded compat shim for OpenSSL < 1.1.0: the Bionic bake pins `libssl1.0-dev` (build.sh), and OpenSSL 1.0.2 has no `HMAC_CTX_new`/`HMAC_CTX_free`. Without the shim this PR breaks the Bionic bake, which stays active until the Jammy cutover.

Root-caused and verified by building brubeck from source (this fork) inside an ubuntu:22.04 container: this was the only compile error blocking a Jammy build. Everything else (vendored ck, jansson, microhttpd) compiles clean with warnings only.

## Test plan
- [x] `git submodule update --init`, then `make brubeck` succeeds (exit 0) on ubuntu:22.04, produces a working binary that runs and prints its usage banner. Verified on amd64 and arm64 (prod brubeck is Graviton).
- [x] Still builds/runs on ubuntu:18.04 with `libssl1.0-dev` (the exact package the Bionic bake installs), amd64 and arm64. Note: the original "source-compatible with OpenSSL 1.1+, which Bionic ships" assumption was wrong for our pipeline; the Bionic bake uses OpenSSL 1.0.2, which lacks the heap HMAC_CTX API. The compat shim covers it, and without the shim the branch fails to link on Bionic (`undefined reference to HMAC_CTX_new`).

## Proof

Before (master), `make brubeck` on ubuntu:22.04:
```
gcc -g -Wall -O3 ... -c src/samplers/statsd-secure.c -o src/samplers/statsd-secure.o
src/samplers/statsd-secure.c: In function 'statsd_secure__thread':
src/samplers/statsd-secure.c:101:18: error: storage size of 'ctx' isn't known
  101 |         HMAC_CTX ctx;
      |                  ^~~
make: *** [Makefile:44: src/samplers/statsd-secure.o] Error 1
```

After (this branch), same container, same command:
```
$ openssl version
OpenSSL 3.0.2 15 Mar 2022 (Library: OpenSSL 3.0.2 15 Mar 2022)
$ make brubeck
...
mv brubeck.new brubeck
$ echo $?
0
$ ls -la brubeck
-rwxr-xr-x 1 root root 264216 Jul  1 02:50 brubeck
$ ./brubeck --help
Usage: ./brubeck [--log LOG_FILE] [--config CONFIG_FILE] [--version]
```

Diff:
```c
-	HMAC_CTX ctx;
+	HMAC_CTX *ctx;
...
-	HMAC_CTX_init(&ctx);
-	HMAC_Init_ex(&ctx, statsd->hmac_key, strlen(statsd->hmac_key), SHA_FUNCTION(), NULL);
+	ctx = HMAC_CTX_new();
+	HMAC_Init_ex(ctx, statsd->hmac_key, strlen(statsd->hmac_key), SHA_FUNCTION(), NULL);
...
-	HMAC_CTX_cleanup(&ctx);
+	HMAC_CTX_free(ctx);
```

plus the compat shim for OpenSSL < 1.1.0 builds:
```c
+/* OpenSSL < 1.1.0 (bionic bakes pin libssl1.0-dev) has no heap HMAC_CTX API */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+static HMAC_CTX *HMAC_CTX_new(void) { ... malloc + HMAC_CTX_init ... }
+static void HMAC_CTX_free(HMAC_CTX *ctx) { ... HMAC_CTX_cleanup + free ... }
+#endif
```


